### PR TITLE
Add SQLAlchemy-backed protein database and query helper

### DIFF
--- a/Database.py
+++ b/Database.py
@@ -1,35 +1,85 @@
-from Protein import Protein
+"""SQLAlchemy-backed protein database utilities."""
 
 from Bio import SeqIO
+from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.types import PickleType
+
+from Protein import Protein, describe
+
+Base = declarative_base()
+
+
+class ProteinModel(Base):
+    """SQLAlchemy model representing a protein."""
+
+    __tablename__ = "proteins"
+
+    id = Column(Integer, primary_key=True)
+    accession = Column(String, unique=True, index=True)
+    description = Column(String)
+    locus = Column(String)
+    organism = Column(String, index=True)
+    sequence = Column(String)
+    embedding = Column(PickleType)
+
 
 def read_fasta(filename):
-    data=[]
-    for record in SeqIO.parse(filename, 'fasta'):
-        data.append(Protein(record.id, record.description, record.locus, record.organism, record.seq))
+    """Read a FASTA file and return a list of Protein objects."""
+
+    data = []
+    for record in SeqIO.parse(filename, "fasta"):
+        accession, description, locus, organism = describe(record.description)
+        data.append(Protein(accession, description, locus, organism, str(record.seq)))
     return data
 
-class ProteinDB:
-    def __init__(self,fasta=None,protein=None):
-        if protein is None:
-            protein=[]
-        if fasta is None:
-            fasta=[]
-        else:
-            read_fasta(fasta)
-        self.proteins=fasta+protein
-        self.proteins.sort()
 
-    def __len__(self):
-        return len(self.proteins)
-    def __getitem__(self, index):
-        return self.proteins[index]
-    def __iter__(self):
-        return iter(self.proteins)
-    def __contains__(self, item):
-        return item in self.proteins
-    def __add__(self, other):
-        self.proteins.extend(other.proteins)
-        self.proteins=list(set(self.proteins))
-        self.proteins.sort()
-    def query(self,query):
+class ProteinDB:
+    """High level helper around a SQLAlchemy session."""
+
+    def __init__(self, url: str = "sqlite:///proteins.db"):
+        self.engine = create_engine(url)
+        Base.metadata.create_all(self.engine)
+        self.Session = sessionmaker(bind=self.engine)
+
+    def add_protein(self, protein: Protein) -> None:
+        """Insert a single Protein into the database."""
+
+        with self.Session() as session:
+            session.add(
+                ProteinModel(
+                    accession=protein.accession,
+                    description=protein.description,
+                    locus=protein.locus,
+                    organism=protein.organism,
+                    sequence=str(protein.sequence),
+                    embedding=protein.Z,
+                )
+            )
+            session.commit()
+
+    def add_from_fasta(self, fasta_path: str) -> None:
+        """Read proteins from a FASTA file and insert them into the DB."""
+
+        proteins = read_fasta(fasta_path)
+        with self.Session() as session:
+            session.add_all(
+                [
+                    ProteinModel(
+                        accession=p.accession,
+                        description=p.description,
+                        locus=p.locus,
+                        organism=p.organism,
+                        sequence=str(p.sequence),
+                        embedding=p.Z,
+                    )
+                    for p in proteins
+                ]
+            )
+            session.commit()
+
+    def session(self):
+        """Return a new session object."""
+
+        return self.Session()
 

--- a/Query.py
+++ b/Query.py
@@ -1,11 +1,57 @@
-from vae_module import Tokenizer, Config, load_vae, encode
-from Bio import SeqIO
-import re
-cfg = Config(model_path="models/vae_epoch380.pt")
-tok = Tokenizer.from_esm()
+"""Query utilities for the SQLAlchemy protein database."""
 
-model = load_vae(cfg,
-                 vocab_size=len(tok.vocab),
-                 pad_idx=tok.pad_idx,
-                 bos_idx=tok.bos_idx)
+from typing import List
 
+import numpy as np
+
+from Database import ProteinDB, ProteinModel
+from Protein import Protein
+
+
+class ProteinQuery:
+    """Convenience wrapper providing common protein queries."""
+
+    def __init__(self, db: ProteinDB):
+        self.Session = db.Session
+
+    def by_accession(self, accession: str) -> List[ProteinModel]:
+        """Return proteins matching a specific accession."""
+
+        with self.Session() as session:
+            return (
+                session.query(ProteinModel)
+                .filter(ProteinModel.accession == accession)
+                .all()
+            )
+
+    def by_organism(self, organism: str) -> List[ProteinModel]:
+        """Return proteins whose organism contains the given text."""
+
+        pattern = f"%{organism}%"
+        with self.Session() as session:
+            return (
+                session.query(ProteinModel)
+                .filter(ProteinModel.organism.ilike(pattern))
+                .all()
+            )
+
+    def description_contains(self, text: str) -> List[ProteinModel]:
+        """Return proteins whose description contains the given text."""
+
+        pattern = f"%{text}%"
+        with self.Session() as session:
+            return (
+                session.query(ProteinModel)
+                .filter(ProteinModel.description.ilike(pattern))
+                .all()
+            )
+
+    def similar_sequence(self, sequence: str, top: int = 5) -> List[ProteinModel]:
+        """Return proteins with embeddings closest to the given sequence."""
+
+        query_protein = Protein("query", "", "", "", sequence)
+        target = query_protein.Z
+        with self.Session() as session:
+            proteins = session.query(ProteinModel).all()
+        proteins.sort(key=lambda p: np.linalg.norm(p.embedding - target))
+        return proteins[:top]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pandas
 scikit-learn
 PyYAML
 tqdm
+sqlalchemy
 
 # Documentation
 sphinx


### PR DESCRIPTION
## Summary
- Replace in-memory ProteinDB with SQLAlchemy model and helper functions
- Add query utilities to search by accession, organism, description, and embedding similarity
- Include SQLAlchemy in requirements

## Testing
- `python -m py_compile Database.py Query.py`
- `python - <<'PY'
from Database import ProteinDB
from sqlalchemy import inspect

db = ProteinDB('sqlite:///:memory:')
print(inspect(db.engine).get_table_names())
PY`


------
https://chatgpt.com/codex/tasks/task_e_689044adc088832ba841c37ac72f5e01